### PR TITLE
Add support for Ruby 2.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,6 +43,7 @@ rspec_task:
     - rubocop
   container:
     matrix:
+      image: ruby:2.4
       image: ruby:2.5
       image: ruby:2.6
       image: ruby:2.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,7 @@ Metrics/BlockLength:
     - lib/gem_toys/template.rb
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.4
   NewCops: enable
 
 RSpec/NestedGroups:

--- a/gem_toys.gemspec
+++ b/gem_toys.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
 	DESC
 	spec.license = 'MIT'
 
-	spec.required_ruby_version = '>= 2.5'
-
 	source_code_uri = 'https://github.com/AlexWayfer/gem_toys'
 
 	spec.homepage = source_code_uri
@@ -28,6 +26,8 @@ Gem::Specification.new do |spec|
 		'https://github.com/AlexWayfer/gem_toys/blob/master/CHANGELOG.md'
 
 	spec.files = Dir['lib/**/*.rb', 'README.md', 'LICENSE.txt', 'CHANGELOG.md']
+
+	spec.required_ruby_version = '>= 2.4'
 
 	spec.add_development_dependency 'pry-byebug', '~> 3.9'
 


### PR DESCRIPTION
`gorilla_patch` (and maybe something else) still supports.