### PR TITLE
Pass arguments to `rspec` and `rubocop` tools

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,11 +30,18 @@ rubocop_task:
   container:
     image: ruby:latest
   <<: *bundle_cache
-  lint_script: toys rubocop
+
+  lint_script: toys rubocop --format=json --out=rubocop.json
+
+  always:
+    rubocop_artifacts:
+      path: rubocop.json
+      type: text/json
+      format: rubocop
+
   only_if: ($CIRRUS_BRANCH == 'master') ||
     changesInclude(
-      '.cirrus.yml', '.gitignore', 'Gemfile', 'Rakefile', '.rubocop.yml', '*.gemspec',
-      '**.rb', '**.ru'
+      '.cirrus.yml', '.gitignore', 'Gemfile', 'Rakefile', '.rubocop.yml', '*.gemspec', '**.rb'
     )
 
 rspec_task:
@@ -50,7 +57,15 @@ rspec_task:
   <<: *bundle_cache
   environment:
     CODECOV_TOKEN: ENCRYPTED[12d1a277340035823607e1a3ea66a111f0c25e0aea80a1ca68cf5406c8a3897bef9aa24803c6e30a7328ce0eb2cbc974]
-  test_script: toys rspec
+
+  test_script: toys rspec --format=json --out=rspec.json
+
+  always:
+    rspec_report_artifacts:
+      path: rspec.json
+      type: text/json
+      format: rspec
+
   only_if: ($CIRRUS_BRANCH == 'master') ||
     changesInclude(
       '.cirrus.yml', '.gitignore', 'Gemfile', 'Rakefile', '.rspec', '*.gemspec', 'lib/**',

--- a/.toys.rb
+++ b/.toys.rb
@@ -12,8 +12,10 @@ expand GemToys::Template
 alias_tool :g, :gem
 
 tool :rspec do
+	disable_argument_parsing
+
 	def run
-		exec 'rspec'
+		exec ['rspec', *args]
 	end
 end
 
@@ -21,7 +23,9 @@ alias_tool :spec, :rspec
 alias_tool :test, :rspec
 
 tool :rubocop do
+	disable_argument_parsing
+
 	def run
-		exec 'rubocop'
+		exec ['rubocop', *args]
 	end
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+*   Pass arguments and options to `rspec` and `rubocop` tasks.
+
 ## 0.3.0 (2020-07-11)
 
 *   Add support for Ruby 2.4


### PR DESCRIPTION
Also report RuboCop and RSpec results for GitHub annotations.