### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,7 +43,6 @@ rspec_task:
     - rubocop
   container:
     matrix:
-      image: ruby:2.4
       image: ruby:2.5
       image: ruby:2.6
       image: ruby:2.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,7 @@ Metrics/BlockLength:
     - lib/gem_toys/template.rb
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 RSpec/NestedGroups:

--- a/gem_toys.gemspec
+++ b/gem_toys.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
 	spec.files = Dir['lib/**/*.rb', 'README.md', 'LICENSE.txt', 'CHANGELOG.md']
 
-	spec.required_ruby_version = '>= 2.4'
+	spec.required_ruby_version = '>= 2.5'
 
 	spec.add_development_dependency 'pry-byebug', '~> 3.9'
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/