### PR TITLE
Drop RSpec and RuboCop toys

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ rubocop_task:
   container:
     image: ruby:latest
   <<: *bundle_cache
-  lint_script: toys rubocop
+  lint_script: bundle exec rubocop
   only_if: ($CIRRUS_BRANCH == 'master') ||
     changesInclude(
       '.cirrus.yml', '.gitignore', 'Gemfile', 'Rakefile', '.rubocop.yml', '*.gemspec',
@@ -49,7 +49,7 @@ rspec_task:
   <<: *bundle_cache
   environment:
     CODECOV_TOKEN: ENCRYPTED[12d1a277340035823607e1a3ea66a111f0c25e0aea80a1ca68cf5406c8a3897bef9aa24803c6e30a7328ce0eb2cbc974]
-  test_script: toys rspec
+  test_script: bundle exec rspec
   only_if: ($CIRRUS_BRANCH == 'master') ||
     changesInclude(
       '.cirrus.yml', '.gitignore', 'Gemfile', 'Rakefile', '.rspec', '*.gemspec', 'lib/**',

--- a/.toys.rb
+++ b/.toys.rb
@@ -10,18 +10,3 @@ require_relative 'lib/gem_toys'
 expand GemToys::Template
 
 alias_tool :g, :gem
-
-tool :rspec do
-	def run
-		exec 'rspec'
-	end
-end
-
-alias_tool :spec, :rspec
-alias_tool :test, :rspec
-
-tool :rubocop do
-	def run
-		exec 'rubocop'
-	end
-end


### PR DESCRIPTION
Just use `bundle exec`.